### PR TITLE
Feature/jiyoung/ainft v2

### DIFF
--- a/contracts/ainft/AINFTBaseV2.sol
+++ b/contracts/ainft/AINFTBaseV2.sol
@@ -12,17 +12,8 @@ import '../interfaces/IAINFTBaseV1.sol';
 
 /**
  * @title AINFTBaseV2
- *
- * @dev Implementation of the [ERC721](https://eips.ethereum.org/EIPS/eip-721)
- * Non-Fungible Token Standard, overriding transfer and approval methods.
- * Only addresses filtered by OpenSea's [Operator Filter Registry](https://github.com/ProjectOpenSea/operator-filter-registry) are allowed.
- *
- * Token IDs are minted in sequential order (e.g. 1, 2, 3, ...)
- *
- * Assumptions:
- *
- * - The maximum mint `quantity` cannot exceed 100.
- * - The token fetch limit is 100.
+ * @dev [ERC721](https://eips.ethereum.org/EIPS/eip-721) compliant,
+ * which supports transfer and approval for allowed operators.
  */
 abstract contract AINFTBaseV2 is
   ERC721Enumerable,

--- a/contracts/ainft/AINFTBaseV2.sol
+++ b/contracts/ainft/AINFTBaseV2.sol
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: UNLICENSED
+// AINFT Contracts v1.0.0
+pragma solidity ^0.8.9;
+
+import {Strings} from '@openzeppelin/contracts/utils/Strings.sol';
+import '@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol';
+import '@openzeppelin/contracts/token/ERC721/extensions/ERC721Burnable.sol';
+import '@openzeppelin/contracts/access/Ownable.sol';
+import '@openzeppelin/contracts/access/AccessControl.sol';
+import 'operator-filter-registry/src/DefaultOperatorFilterer.sol';
+import '../interfaces/IAINFTBaseV1.sol';
+
+abstract contract AINFTBaseV2 is
+  ERC721Enumerable,
+  ERC721Burnable,
+  Ownable,
+  AccessControl,
+  DefaultOperatorFilterer
+{
+  using Strings for uint256;
+
+  error InvalidLimit(uint256 limit, uint8 tokenFetchLimit);
+  error InvalidOffset(uint256 offset, uint256 balance);
+
+  bytes32 public constant OWNER_ROLE = keccak256('OWNER');
+  bytes32 public constant MINTER_ROLE = keccak256('MINTER');
+  uint256 public nextTokenId = 1;
+  uint256 public maxTokenId;
+  uint8 public constant MAX_MINT_QUANTITY = 100;
+  uint8 public constant TOKEN_FETCH_LIMIT = 100;
+  string public baseURI = '';
+
+  event Mint(
+    address indexed to,
+    uint256 indexed startTokenId,
+    uint256 quantity
+  );
+
+  constructor(
+    string memory name_,
+    string memory symbol_,
+    string memory baseURI_,
+    uint256 maxTokenId_
+  ) ERC721(name_, symbol_) {
+    require(bytes(baseURI_).length > 0, 'AINFTv2: invalid baseURI_');
+    require(maxTokenId_ > 0, 'AINFTv2: invalid maxTokenId_');
+
+    _grantRole(OWNER_ROLE, msg.sender);
+    _grantRole(MINTER_ROLE, msg.sender);
+    _setRoleAdmin(MINTER_ROLE, OWNER_ROLE);
+
+    baseURI = baseURI_;
+    maxTokenId = maxTokenId_;
+  }
+
+  // ============= QUERY
+
+  function supportsInterface(bytes4 interfaceId_)
+    public
+    view
+    virtual
+    override(AccessControl, ERC721, ERC721Enumerable)
+    returns (bool)
+  {
+    return
+      type(IAINFTBaseV1).interfaceId == interfaceId_ ||
+      super.supportsInterface(interfaceId_);
+  }
+
+  function tokenURI(uint256 tokenId_)
+    public
+    view
+    override
+    returns (string memory)
+  {
+    require(_exists(tokenId_), 'AINFTv2: URI query for nonexistent token');
+    require(bytes(baseURI).length > 0, 'AINFTv2: invalid baseURI');
+
+    return string(abi.encodePacked(baseURI, tokenId_.toString()));
+  }
+
+  /**
+   * @dev Returns the token IDs of the owner, starting at the `offset_` ending at `offset_ + limit_ - 1`
+   * @param owner_ address of the owner
+   * @param offset_ index offset to start enumerating within the ownedTokens list of the owner
+   * @param limit_ max number of IDs to fetch
+   */
+  function tokensOf(
+    address owner_,
+    uint256 offset_,
+    uint256 limit_
+  ) public view returns (uint256[] memory) {
+    uint256 balance = ERC721.balanceOf(owner_);
+    if (limit_ == 0 || limit_ > TOKEN_FETCH_LIMIT) {
+      revert InvalidLimit(limit_, TOKEN_FETCH_LIMIT);
+    }
+    if (offset_ >= balance) {
+      revert InvalidOffset(offset_, balance);
+    }
+
+    uint256 numToReturn = (offset_ + limit_ <= balance)
+      ? limit_
+      : balance - offset_;
+    uint256[] memory ownedTokens = new uint256[](numToReturn);
+    for (uint256 i = 0; i < numToReturn; i++) {
+      ownedTokens[i] = tokenOfOwnerByIndex(owner_, offset_ + i);
+    }
+    return ownedTokens;
+  }
+
+  // ============= TX
+
+  function setBaseURI(string calldata baseURI_) public onlyRole(OWNER_ROLE) {
+    require(bytes(baseURI_).length > 0, 'AINFTv2: invalid baseURI_');
+    baseURI = baseURI_;
+  }
+
+  function setMaxTokenId(uint256 maxTokenId_) public onlyRole(OWNER_ROLE) {
+    require(nextTokenId - 1 <= maxTokenId_, 'AINFTv2: invalid maxTokenId_');
+    maxTokenId = maxTokenId_;
+  }
+
+  function mint(address to_, uint8 quantity_)
+    public
+    virtual
+    onlyRole(MINTER_ROLE)
+    returns (uint256)
+  {
+    require(to_ != address(0), 'AINFTv2: invalid to_ address');
+    require(
+      0 < quantity_ && quantity_ <= MAX_MINT_QUANTITY,
+      'AINFTv2: invalid quantity_'
+    );
+    require(
+      nextTokenId + quantity_ - 1 <= maxTokenId,
+      'AINFTv2: exceeds maxTokenId'
+    );
+
+    uint256 startTokenId = nextTokenId;
+    for (uint8 i = 0; i < quantity_; i++) {
+      _safeMint(to_, nextTokenId);
+      nextTokenId += 1;
+    }
+    emit Mint(to_, startTokenId, quantity_);
+
+    return startTokenId;
+  }
+
+  function burn(uint256 tokenId_) public virtual override onlyRole(OWNER_ROLE) {
+    _burn(tokenId_);
+  }
+
+  function destroy(address payable to_) public onlyRole(OWNER_ROLE) {
+    require(to_ != address(0), 'AINFTv2: invalid to_ address');
+    selfdestruct(to_);
+  }
+
+  // ============= OPENSEA REGISTRY
+
+  function setApprovalForAll(address operator, bool approved)
+    public
+    override(ERC721, IERC721)
+    onlyAllowedOperatorApproval(operator)
+  {
+    super.setApprovalForAll(operator, approved);
+  }
+
+  function approve(address operator, uint256 tokenId)
+    public
+    override(ERC721, IERC721)
+    onlyAllowedOperatorApproval(operator)
+  {
+    super.approve(operator, tokenId);
+  }
+
+  function transferFrom(
+    address from,
+    address to,
+    uint256 tokenId
+  ) public override(ERC721, IERC721) onlyAllowedOperator(from) {
+    super.transferFrom(from, to, tokenId);
+  }
+
+  function safeTransferFrom(
+    address from,
+    address to,
+    uint256 tokenId
+  ) public override(ERC721, IERC721) onlyAllowedOperator(from) {
+    super.safeTransferFrom(from, to, tokenId);
+  }
+
+  function safeTransferFrom(
+    address from,
+    address to,
+    uint256 tokenId,
+    bytes memory data
+  ) public override(ERC721, IERC721) onlyAllowedOperator(from) {
+    super.safeTransferFrom(from, to, tokenId, data);
+  }
+
+  // ============= HOOKS
+
+  function _beforeTokenTransfer(
+    address from_,
+    address to_,
+    uint256 tokenId_
+  ) internal override(ERC721, ERC721Enumerable) {
+    super._beforeTokenTransfer(from_, to_, tokenId_);
+  }
+}

--- a/contracts/ainft/AINFTBaseV2.sol
+++ b/contracts/ainft/AINFTBaseV2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-// AINFT Contracts v1.0.0
+// AINFT Contracts v2.0.0
 pragma solidity ^0.8.9;
 
 import {Strings} from '@openzeppelin/contracts/utils/Strings.sol';
@@ -10,6 +10,20 @@ import '@openzeppelin/contracts/access/AccessControl.sol';
 import 'operator-filter-registry/src/DefaultOperatorFilterer.sol';
 import '../interfaces/IAINFTBaseV1.sol';
 
+/**
+ * @title AINFTBaseV2
+ *
+ * @dev Implementation of the [ERC721](https://eips.ethereum.org/EIPS/eip-721)
+ * Non-Fungible Token Standard, overriding transfer and approval methods.
+ * Only addresses filtered by OpenSea's [Operator Filter Registry](https://github.com/ProjectOpenSea/operator-filter-registry) are allowed.
+ *
+ * Token IDs are minted in sequential order (e.g. 1, 2, 3, ...)
+ *
+ * Assumptions:
+ *
+ * - The maximum mint `quantity` cannot exceed 100.
+ * - The token fetch limit is 100.
+ */
 abstract contract AINFTBaseV2 is
   ERC721Enumerable,
   ERC721Burnable,

--- a/contracts/mock/AINFTv2Mock.sol
+++ b/contracts/mock/AINFTv2Mock.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.9;
+import '../ainft/AINFTBaseV2.sol';
+
+contract AINFTv2Mock is AINFTBaseV2 {
+  constructor(
+    string memory name_,
+    string memory symbol_,
+    string memory baseURI_,
+    uint256 maxTokenId_
+  ) AINFTBaseV2(name_, symbol_, baseURI_, maxTokenId_) {}
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,5 +1,6 @@
 import { HardhatUserConfig } from 'hardhat/config';
 import '@nomicfoundation/hardhat-toolbox';
+import '@nomicfoundation/hardhat-chai-matchers';
 import 'solidity-coverage';
 import '@typechain/hardhat';
 import '@nomiclabs/hardhat-ethers';

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "typescript": ">=4.5.0"
   },
   "dependencies": {
-    "@openzeppelin/contracts": "4.7.3"
+    "@openzeppelin/contracts": "4.7.3",
+    "operator-filter-registry": "^1.4.0"
   }
 }

--- a/test/AINFTv2Mock.ts
+++ b/test/AINFTv2Mock.ts
@@ -171,8 +171,20 @@ describe('AINFTv2Mock', function () {
         expect(await ainftV2Mock.balanceOf(userAddr)).to.equal(1);
       });
 
-      // TODO: Add test case for token transfer from one account to another.
-      // ...
+      it("Should transfer token from the 'from' address to the 'to' address", async function () {
+        const { ainftV2Mock, minter, users } = await loadFixture(deployAINFTv2MockFixture);
+
+        await expect(ainftV2Mock.connect(minter).mint(users[0].address, 1)).not.to.be.reverted;
+        expect(await ainftV2Mock.ownerOf(1)).to.equal(users[0].address);
+        expect(await ainftV2Mock.balanceOf(users[0].address)).to.equal(1);
+        expect(await ainftV2Mock.balanceOf(users[1].address)).to.equal(0);
+        
+        await ainftV2Mock.connect(users[0])
+          ["safeTransferFrom(address,address,uint256)"](users[0].address, users[1].address, 1);
+        expect(await ainftV2Mock.ownerOf(1)).to.equal(users[1].address);
+        expect(await ainftV2Mock.balanceOf(users[0].address)).to.equal(0);
+        expect(await ainftV2Mock.balanceOf(users[1].address)).to.equal(1);
+      });
     });
   });
 

--- a/test/AINFTv2Mock.ts
+++ b/test/AINFTv2Mock.ts
@@ -1,0 +1,304 @@
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+
+const name = 'AINFT V2 Mock';
+const symbol = 'AINFTV2MOCK';
+const baseURI = 'http://localhost:3000/';
+const maxTokenId = 10;
+
+describe('AINFTv2Mock', function () {
+  // We define a fixture to reuse the same setup in every test.
+  // We use loadFixture to run this setup once, snapshot that state,
+  // and reset Hardhat Network to that snapshot in every test.
+  async function deployAINFTv2MockFixture() {
+    // Contracts are deployed using the first signer/account by default
+    const [owner, minter, ...users] = await ethers.getSigners();
+    const AINFTv2Mock = await ethers.getContractFactory('AINFTv2Mock');
+    const ainftV2Mock = await AINFTv2Mock.deploy(name, symbol, baseURI, maxTokenId);
+
+    const minterRole = await ainftV2Mock.MINTER_ROLE();
+    await ainftV2Mock.connect(owner).grantRole(minterRole, minter.address);
+
+    return { ainftV2Mock, owner, minter, users };
+  }
+
+  describe('Deployment', function () {
+    it('Should set the right owner', async function () {
+      const { ainftV2Mock, owner } = await loadFixture(deployAINFTv2MockFixture);
+
+      expect(await ainftV2Mock.owner()).to.equal(owner.address);
+    });
+
+    it('Should set the right name', async function () {
+      const { ainftV2Mock } = await loadFixture(deployAINFTv2MockFixture);
+
+      expect(await ainftV2Mock.name()).to.equal(name);
+    });
+
+    it('Should set the right symbol', async function () {
+      const { ainftV2Mock } = await loadFixture(deployAINFTv2MockFixture);
+
+      expect(await ainftV2Mock.symbol()).to.equal(symbol);
+    });
+
+    it('Should set the right baseURI', async function () {
+      const { ainftV2Mock } = await loadFixture(deployAINFTv2MockFixture);
+
+      expect(await ainftV2Mock.baseURI()).to.equal(baseURI);
+    });
+
+    it('Should set the right maxTokenId', async function () {
+      const { ainftV2Mock } = await loadFixture(deployAINFTv2MockFixture);
+
+      expect(await ainftV2Mock.maxTokenId()).to.equal(maxTokenId);
+    });
+
+    it('Should support AINFTv2 interface', async function () {
+      const { ainftV2Mock } = await loadFixture(deployAINFTv2MockFixture);
+
+      expect(await ainftV2Mock.supportsInterface(0xffffffff)).to.equal(false);
+
+      expect(await ainftV2Mock.supportsInterface(0x01ffc9a7)).to.equal(true); // ERC165
+      expect(await ainftV2Mock.supportsInterface(0x80ac58cd)).to.equal(true); // ERC721
+      expect(await ainftV2Mock.supportsInterface(0x780e9d63)).to.equal(true); // ERC721Enumerable
+      expect(await ainftV2Mock.supportsInterface(0x5b5e139f)).to.equal(true); // ERC721Metadata
+      expect(await ainftV2Mock.supportsInterface(0x7965db0b)).to.equal(true); // AccessControl
+      expect(await ainftV2Mock.supportsInterface(0x9de93351)).to.equal(true); // IAINFTBaseV1
+    });
+  });
+
+  describe('Roles', function () {
+    it('Should fail to grantRole if sender is unauthorized', async () => {
+      const { ainftV2Mock, users } = await loadFixture(deployAINFTv2MockFixture);
+      await expect(
+        ainftV2Mock.connect(users[0]).grantRole(await ainftV2Mock.MINTER_ROLE(), users[0].address),
+      ).to.be.revertedWith(
+        'AccessControl: account 0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc is missing role 0x6270edb7c868f86fda4adedba75108201087268ea345934db8bad688e1feb91b',
+      );
+    });
+
+    it('Should grantRole', async () => {
+      const { ainftV2Mock, owner, users } = await loadFixture(deployAINFTv2MockFixture);
+      const minterRole = await ainftV2Mock.MINTER_ROLE();
+      expect(await ainftV2Mock.hasRole(minterRole, users[0].address)).to.equal(false);
+      await ainftV2Mock.connect(owner).grantRole(minterRole, users[0].address);
+      expect(await ainftV2Mock.hasRole(minterRole, users[0].address)).to.equal(true);
+    });
+  });
+
+  describe('Mint', function () {
+    describe('Validations', function () {
+      it('Should revert with the right error if sender is not authorized', async function () {
+        const { ainftV2Mock, users } = await loadFixture(deployAINFTv2MockFixture);
+
+        await expect(ainftV2Mock.connect(users[0]).mint(users[0].address, 1)).to.be.revertedWith(
+          'AccessControl: account 0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc is missing role 0xf0887ba65ee2024ea881d91b74c2450ef19e1557f03bed3ea9f16b037cbe2dc9',
+        );
+      });
+
+      it("Should revert with the right error if invalid 'to' address given", async function () {
+        const { ainftV2Mock, minter } = await loadFixture(deployAINFTv2MockFixture);
+
+        await expect(ainftV2Mock.connect(minter).mint(ethers.constants.AddressZero, 1)).to.be.revertedWith(
+          'AINFTv2: invalid to_ address',
+        );
+      });
+
+      it('Should revert with invalid quantity is given', async function () {
+        const { ainftV2Mock, minter } = await loadFixture(deployAINFTv2MockFixture);
+
+        await expect(ainftV2Mock.connect(minter).mint(minter.address, 0)).to.be.revertedWith(
+          'AINFTv2: invalid quantity_',
+        );
+        await expect(ainftV2Mock.connect(minter).mint(minter.address, 101)).to.be.revertedWith(
+          'AINFTv2: invalid quantity_',
+        );
+      });
+
+      it('Should revert with the right error if exceeds maxTokenId', async function () {
+        const { ainftV2Mock, minter, users } = await loadFixture(deployAINFTv2MockFixture);
+
+        await expect(ainftV2Mock.connect(minter).mint(users[0].address, maxTokenId)).not.to.be.reverted;
+        await expect(ainftV2Mock.connect(minter).mint(users[0].address, 1)).to.be.revertedWith(
+          'AINFTv2: exceeds maxTokenId',
+        );
+      });
+
+      it('Should mint', async function () {
+        const { ainftV2Mock, minter, users } = await loadFixture(deployAINFTv2MockFixture);
+
+        const userAddr = users[0].address;
+        await expect(ainftV2Mock.connect(minter).mint(userAddr, 1)).not.to.be.reverted;
+        expect(await ainftV2Mock.totalSupply()).to.equal(1);
+        expect(await ainftV2Mock.nextTokenId()).to.equal(2);
+        expect(await ainftV2Mock.balanceOf(userAddr)).to.equal(1);
+        expect(await ainftV2Mock.ownerOf(1)).to.equal(userAddr);
+        expect(await ainftV2Mock.tokensOf(userAddr, 0, 1)).to.deep.equal(['1']);
+      });
+    });
+
+    describe('Events', function () {
+      it('Should emit an event on mint', async function () {
+        const { ainftV2Mock, minter, users } = await loadFixture(deployAINFTv2MockFixture);
+
+        const expectedTokenId = (await ainftV2Mock.nextTokenId()).toNumber();
+        await expect(ainftV2Mock.connect(minter).mint(users[0].address, 1))
+          .to.emit(ainftV2Mock, 'Mint')
+          .withArgs(users[0].address, expectedTokenId, 1);
+      });
+
+      it('Should emit right events on batch mint', async function () {
+        const { ainftV2Mock, minter, users } = await loadFixture(deployAINFTv2MockFixture);
+
+        const expectedTokenId = (await ainftV2Mock.nextTokenId()).toNumber();
+        await expect(ainftV2Mock.connect(minter).mint(users[0].address, 3))
+          .to.emit(ainftV2Mock, 'Mint')
+          .withArgs(users[0].address, expectedTokenId, 3);
+      });
+    });
+
+    describe('Transfers', function () {
+      it("Should transfer token to the 'to' address", async function () {
+        const { ainftV2Mock, minter, users } = await loadFixture(deployAINFTv2MockFixture);
+
+        const userAddr = users[0].address;
+        const expectedTokenId = (await ainftV2Mock.nextTokenId()).toNumber();
+        await expect(ainftV2Mock.connect(minter).mint(userAddr, 1))
+          .to.emit(ainftV2Mock,'Transfer')
+          .withArgs(ethers.constants.AddressZero, users[0].address, expectedTokenId);
+        expect(await ainftV2Mock.ownerOf(expectedTokenId)).to.equal(userAddr);
+        expect(await ainftV2Mock.balanceOf(userAddr)).to.equal(1);
+      });
+
+      // TODO: Add test case for token transfer from one account to another.
+      // ...
+    });
+  });
+
+  describe('Tokens Of', function () {
+    it('Should fail if invalid limit is given', async () => {
+      const { ainftV2Mock, minter, users } = await loadFixture(deployAINFTv2MockFixture);
+
+      await expect(ainftV2Mock.connect(minter).mint(users[0].address, 1)).not.to.be.reverted;
+      await expect(ainftV2Mock.tokensOf(users[0].address, 0, 0))
+        .to.be.revertedWithCustomError(ainftV2Mock, 'InvalidLimit')
+        .withArgs(0, 100);
+      await expect(ainftV2Mock.tokensOf(users[0].address, 0, 101))
+        .to.be.revertedWithCustomError(ainftV2Mock, 'InvalidLimit')
+        .withArgs(101, 100);
+    });
+
+    it('Should fail if invalid offset is given', async () => {
+      const { ainftV2Mock, minter, users } = await loadFixture(deployAINFTv2MockFixture);
+
+      await expect(ainftV2Mock.connect(minter).mint(users[0].address, 1)).not.to.be.reverted;
+      await expect(ainftV2Mock.tokensOf(users[0].address, 2, 1))
+        .to.be.revertedWithCustomError(ainftV2Mock, 'InvalidOffset')
+        .withArgs(2, 1);
+    });
+
+    it('Should return the right tokens owned by accounts', async () => {
+      const { ainftV2Mock, minter, users } = await loadFixture(deployAINFTv2MockFixture);
+
+      await expect(ainftV2Mock.connect(minter).mint(users[0].address, 2)).not.to.be.reverted; // 1, 2
+      await expect(ainftV2Mock.connect(minter).mint(users[1].address, 1)).not.to.be.reverted; // 3
+      await expect(ainftV2Mock.connect(minter).mint(users[0].address, 1)).not.to.be.reverted; // 4
+      expect(await ainftV2Mock.tokensOf(users[0].address, 0, 10)).to.deep.equal(['1', '2', '4']);
+      expect(await ainftV2Mock.tokensOf(users[1].address, 0, 10)).to.deep.equal(['3']);
+    });
+  });
+
+  describe('Burn', function () {
+    it('Should fail with a nonexistent token ID', async () => {
+      const { ainftV2Mock, owner } = await loadFixture(deployAINFTv2MockFixture);
+
+      await expect(ainftV2Mock.connect(owner).burn(1)).to.be.revertedWith('ERC721: invalid token ID');
+    });
+
+    it('Should fail if sender is unauthorized', async () => {
+      const { ainftV2Mock, minter } = await loadFixture(deployAINFTv2MockFixture);
+
+      await expect(ainftV2Mock.connect(minter).mint(minter.address, 1)).not.to.be.reverted;
+      await expect(ainftV2Mock.connect(minter).burn(1)).to.be.revertedWith(
+        'AccessControl: account 0x70997970c51812dc3a010c7d01b50e0d17dc79c8 is missing role 0x6270edb7c868f86fda4adedba75108201087268ea345934db8bad688e1feb91b',
+      );
+    });
+
+    it('Should burn', async () => {
+      const { ainftV2Mock, owner, minter, users } = await loadFixture(deployAINFTv2MockFixture);
+      const userAddr = users[0].address;
+      await expect(ainftV2Mock.connect(minter).mint(userAddr, 1)).not.to.be.reverted;
+      await expect(ainftV2Mock.connect(owner).burn(1))
+        .to.emit(ainftV2Mock, 'Transfer')
+        .withArgs(userAddr, ethers.constants.AddressZero, 1);
+      expect(await ainftV2Mock.totalSupply()).to.equal(0);
+      expect(await ainftV2Mock.nextTokenId()).to.equal(2);
+      expect(await ainftV2Mock.balanceOf(userAddr)).to.equal(0);
+      await expect(ainftV2Mock.ownerOf(1)).to.be.revertedWith('ERC721: invalid token ID');
+      await expect(ainftV2Mock.tokensOf(userAddr, 0, 1))
+        .to.be.revertedWithCustomError(ainftV2Mock, 'InvalidOffset')
+        .withArgs(0, 0);
+    });
+  });
+
+  describe('Set maxTokenId', function () {
+    it('Should fail if sender is unauthorized', async () => {
+      const { ainftV2Mock, minter } = await loadFixture(deployAINFTv2MockFixture);
+
+      await expect(ainftV2Mock.connect(minter).setMaxTokenId(1000)).to.be.revertedWith(
+        'AccessControl: account 0x70997970c51812dc3a010c7d01b50e0d17dc79c8 is missing role 0x6270edb7c868f86fda4adedba75108201087268ea345934db8bad688e1feb91b',
+      );
+    });
+
+    it('Should fail with an invalid value', async () => {
+      const { ainftV2Mock, owner, minter, users } = await loadFixture(deployAINFTv2MockFixture);
+      const userAddr = users[0].address;
+
+      // mint 2 tokens to make nextTokenId - 2 > 0
+      await ainftV2Mock.connect(minter).mint(userAddr, 2);
+      const nextTokenId = (await ainftV2Mock.nextTokenId()).toNumber();
+      await expect(ainftV2Mock.connect(owner).setMaxTokenId(nextTokenId - 2)).to.be.revertedWith(
+        'AINFTv2: invalid maxTokenId_',
+      );
+    });
+
+    it('Should set maxTokenId', async () => {
+      const { ainftV2Mock, owner, minter, users } = await loadFixture(deployAINFTv2MockFixture);
+
+      await ainftV2Mock.connect(owner).setMaxTokenId((await ainftV2Mock.nextTokenId()).toNumber() - 1);
+      await expect(ainftV2Mock.connect(minter).mint(users[0].address, 1)).to.be.revertedWith(
+        'AINFTv2: exceeds maxTokenId',
+      );
+    });
+  });
+
+  describe('Destroy', function () {
+    it('Should fail if sender is unauthorized', async () => {
+      const { ainftV2Mock, minter } = await loadFixture(deployAINFTv2MockFixture);
+
+      await expect(ainftV2Mock.connect(minter).destroy(minter.address)).to.be.revertedWith(
+        'AccessControl: account 0x70997970c51812dc3a010c7d01b50e0d17dc79c8 is missing role 0x6270edb7c868f86fda4adedba75108201087268ea345934db8bad688e1feb91b',
+      );
+    });
+
+    it('Should fail with an invalid payable address', async () => {
+      const { ainftV2Mock, owner } = await loadFixture(deployAINFTv2MockFixture);
+
+      await expect(ainftV2Mock.connect(owner).destroy(ethers.constants.AddressZero)).to.be.revertedWith(
+        'AINFTv2: invalid to_ address',
+      );
+    });
+
+    it('Should destroy', async () => {
+      const { ainftV2Mock, owner, minter, users } = await loadFixture(deployAINFTv2MockFixture);
+
+      await ainftV2Mock.connect(owner).destroy(owner.address);
+      await expect(ainftV2Mock.nextTokenId()).to.be.reverted;
+      const tx = await ainftV2Mock.connect(minter).mint(users[0].address, 1);
+      const receipt = await tx.wait(1);
+      expect(receipt.logs.length).to.equal(0);
+      expect(receipt?.events?.length).to.equal(0);
+    });
+  });
+});

--- a/test/AINFTv2Mock.ts
+++ b/test/AINFTv2Mock.ts
@@ -165,7 +165,7 @@ describe('AINFTv2Mock', function () {
         const userAddr = users[0].address;
         const expectedTokenId = (await ainftV2Mock.nextTokenId()).toNumber();
         await expect(ainftV2Mock.connect(minter).mint(userAddr, 1))
-          .to.emit(ainftV2Mock,'Transfer')
+          .to.emit(ainftV2Mock, 'Transfer')
           .withArgs(ethers.constants.AddressZero, users[0].address, expectedTokenId);
         expect(await ainftV2Mock.ownerOf(expectedTokenId)).to.equal(userAddr);
         expect(await ainftV2Mock.balanceOf(userAddr)).to.equal(1);
@@ -178,9 +178,10 @@ describe('AINFTv2Mock', function () {
         expect(await ainftV2Mock.ownerOf(1)).to.equal(users[0].address);
         expect(await ainftV2Mock.balanceOf(users[0].address)).to.equal(1);
         expect(await ainftV2Mock.balanceOf(users[1].address)).to.equal(0);
-        
-        await ainftV2Mock.connect(users[0])
-          ["safeTransferFrom(address,address,uint256)"](users[0].address, users[1].address, 1);
+
+        await ainftV2Mock
+          .connect(users[0])
+          ['safeTransferFrom(address,address,uint256)'](users[0].address, users[1].address, 1);
         expect(await ainftV2Mock.ownerOf(1)).to.equal(users[1].address);
         expect(await ainftV2Mock.balanceOf(users[0].address)).to.equal(0);
         expect(await ainftV2Mock.balanceOf(users[1].address)).to.equal(1);

--- a/yarn.lock
+++ b/yarn.lock
@@ -680,10 +680,20 @@
     table "^6.8.0"
     undici "^5.4.0"
 
+"@openzeppelin/contracts-upgradeable@^4.8.0":
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.8.1.tgz#363f7dd08f25f8f77e16d374350c3d6b43340a7a"
+  integrity sha512-1wTv+20lNiC0R07jyIAbHU7TNHKRwGiTGRfiNnA8jOWjKT98g5OgLpYWOi40Vgpk8SPLA9EvfJAbAeIyVn+7Bw==
+
 "@openzeppelin/contracts@4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.7.3.tgz#939534757a81f8d69cc854c7692805684ff3111e"
   integrity sha512-dGRS0agJzu8ybo44pCIf3xBaPQN/65AIXNgK8+4gzKd5kbvlqyxryUYVLJv7fK98Seyd2hDZzVEHSWAh0Bt1Yw==
+
+"@openzeppelin/contracts@^4.7.3":
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.8.1.tgz#709cfc4bbb3ca9f4460d60101f15dac6b7a2d5e4"
+  integrity sha512-xQ6eUZl+RDyb/FiZe1h+U7qr/f4p/SrTSQcTPH2bjur3C5DbuW/zFgCU/b1P/xcIaEqJep+9ju4xDRi3rmChdQ==
 
 "@scure/base@~1.1.0":
   version "1.1.1"
@@ -3848,6 +3858,14 @@ onetime@^2.0.0:
   integrity sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==
   dependencies:
     mimic-fn "^1.0.0"
+
+operator-filter-registry@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/operator-filter-registry/-/operator-filter-registry-1.4.0.tgz#3933fb0e4dba862bbb9655506a89becf0bdc0f32"
+  integrity sha512-BPm5/oF/mLobK8Or795wmQqHx/j0eKMv35Z4HQWTykBPGJHyFUUBsVreo4Z8cj2f0m/3IbQJTHwml6dm3crkPQ==
+  dependencies:
+    "@openzeppelin/contracts" "^4.7.3"
+    "@openzeppelin/contracts-upgradeable" "^4.8.0"
 
 optionator@^0.8.1, optionator@^0.8.2:
   version "0.8.3"


### PR DESCRIPTION
- Added `AINFTBaseV2.sol` and `AINFTv2Mock.sol` contracts. 
  - Overwrote ERC721 transfer and approval methods. 
  - Used [OpenSea Blacklist](https://github.com/ProjectOpenSea/operator-filter-registry). 
- Added tests for `AINFTv2Mock.sol`. 
- To be published to the npm Registry(~~release/1.0.2~~ -> 1.1.0).